### PR TITLE
Added pause/resume methods in Soloud class.

### DIFF
--- a/include/soloud.h
+++ b/include/soloud.h
@@ -106,6 +106,7 @@ namespace SoLoud
 	typedef void (*mutexCallFunction)(void *aMutexPtr);
 	typedef void (*soloudCallFunction)(Soloud *aSoloud);
 	typedef unsigned int result;
+	typedef result (*soloudResultFunction)(Soloud *aSoloud);
 	typedef unsigned int handle;
 	typedef double time;
 };
@@ -165,6 +166,10 @@ namespace SoLoud
 		// Called by SoLoud to shut down the back-end. If NULL, not called. Should be set by back-end.
 		soloudCallFunction mBackendCleanupFunc;
 
+		// Some backends like CoreAudio on iOS must be paused/resumed in some cases. On incoming call as instance.
+		soloudResultFunction mBackendPauseFunc;
+		soloudResultFunction mBackendResumeFunc;
+
 		// CTor
 		Soloud();
 		// DTor
@@ -223,6 +228,9 @@ namespace SoLoud
 
 		// Initialize SoLoud. Must be called before SoLoud can be used.
 		result init(unsigned int aFlags = Soloud::CLIP_ROUNDOFF, unsigned int aBackend = Soloud::AUTO, unsigned int aSamplerate = Soloud::AUTO, unsigned int aBufferSize = Soloud::AUTO, unsigned int aChannels = 2);
+
+		result pause();
+		result resume();
 
 		// Deinitialize SoLoud. Must be called before shutting down.
 		void deinit();

--- a/src/backend/coreaudio/soloud_coreaudio.cpp
+++ b/src/backend/coreaudio/soloud_coreaudio.cpp
@@ -55,7 +55,27 @@ namespace SoLoud
 		AudioQueueStop(audioQueue, true);
 		AudioQueueDispose(audioQueue, false);
 	}
+
+	result soloud_coreaudio_pause(SoLoud::Soloud *aSoloud)
+	{
+		if (!audioQueue)
+			return UNKNOWN_ERROR;
+
+		AudioQueuePause(audioQueue);			// TODO: Error code
+
+		return 0;
+	}
+
+	result soloud_coreaudio_resume(SoLoud::Soloud *aSoloud)
+	{
+		if (!audioQueue)
+			return UNKNOWN_ERROR;
 	
+		AudioQueueStart(audioQueue, nil);		// TODO: Error code
+
+		return 0;
+	}
+
 	static void coreaudio_mutex_lock(void *mutex)
 	{
 		Thread::lockMutex(mutex);
@@ -77,6 +97,8 @@ namespace SoLoud
 	{
 		aSoloud->postinit_internal(aSamplerate, aBuffer, aFlags, 2);
 		aSoloud->mBackendCleanupFunc = soloud_coreaudio_deinit;
+		aSoloud->mBackendPauseFunc = soloud_coreaudio_pause;
+		aSoloud->mBackendResumeFunc = soloud_coreaudio_resume;
 
 		AudioStreamBasicDescription audioFormat;
 		audioFormat.mSampleRate = aSamplerate;
@@ -122,6 +144,6 @@ namespace SoLoud
 
         aSoloud->mBackendString = "CoreAudio";
 		return 0;
-	}	
+	}
 };
 #endif

--- a/src/core/soloud.cpp
+++ b/src/core/soloud.cpp
@@ -116,6 +116,8 @@ namespace SoLoud
 		mAudioThreadMutex = NULL;
 		mPostClipScaler = 0;
 		mBackendCleanupFunc = NULL;
+		mBackendPauseFunc = NULL;
+		mBackendResumeFunc = NULL;
 		mChannels = 2;		
 		mStreamTime = 0;
 		mLastClockedTime = 0;
@@ -565,6 +567,23 @@ namespace SoLoud
 			return UNKNOWN_ERROR;
 		return 0;
 	}
+
+	result Soloud::pause()
+	{
+		if (mBackendPauseFunc)
+			return mBackendPauseFunc(this);
+
+		return NOT_IMPLEMENTED;
+	}
+
+	result Soloud::resume()
+	{
+		if (mBackendResumeFunc)
+			return mBackendResumeFunc(this);
+
+		return NOT_IMPLEMENTED;
+	}
+
 
 	void Soloud::postinit_internal(unsigned int aSamplerate, unsigned int aBufferSize, unsigned int aFlags, unsigned int aChannels)
 	{		


### PR DESCRIPTION
Some backends like CoreAudio on iOS must be paused/resumed in some cases. On incoming call as instance.

> 1. Remove this template before submitting
>
> 2. SoLoud project requires extremely liberal licensing, i.e, no attribution is required for binary forms.
>    Patches should come under zlib, cc0, unlicense or wtfpl license, or if you wish to not retain any
>    rights, don't include a license and the rights of your patch are released to the project owner and
>    included under the SoLoud zlib/libpng licensing for anyone to (ab)use.
>
> 3. Code should generally follow the coding conventions in SoLoud, meaning formatting that's basically 
>    the ANSI format in Artistic Style formatter (or just read some of the code and make yours look the
>    same).
>
> 4. Code should generally follow "Orthodox C++" rules, i.e, not "modern c++". This means minimal template
>    use and basically no "new" c++ features.
>
> 5. Platform-specific code (i.e, backends / sinks) are pretty much expected to break the 3. and 4. above.
>
> 6. To show that you understand and accept the rules above, add your name to the AUTHORS file.
>
> TL;DR: make code similar to what's in SoLoud, don't add new licensing requirements, sign the AUTHORS file, thanks.
